### PR TITLE
Remove configuration to install or not metrics-server

### DIFF
--- a/aws/config.ts
+++ b/aws/config.ts
@@ -69,7 +69,6 @@ export const akkaOperatorChartOpts: ChartOpts = {
 
 export const operatorNamespace = config.get<string>("akka.operator.namespace") || LightbendNamespace;
 
-export const installMetricsServer = getBooleanOrDefault("kubernetes.metrics-server.install", true);
 export const deployKafkaCluster = getBooleanOrDefault("mks.createCluster", true);
 export const deployJdbcDatabase = getBooleanOrDefault("rds.createCluster", true);
 

--- a/aws/index.ts
+++ b/aws/index.ts
@@ -17,13 +17,11 @@ export const kubeconfig = cluster.kubeconfig;
 export const clusterName = cluster.name;
 
 // Install k8s metrics-server
-if (config.installMetricsServer) {
-  new k8s.yaml.ConfigGroup(
-    "metrics-server",
-    { files: "https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.4.4/components.yaml" },
-    { provider: cluster.k8sProvider },
-  );
-}
+new k8s.yaml.ConfigGroup(
+  "metrics-server",
+  { files: "https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.4.4/components.yaml" },
+  { provider: cluster.k8sProvider },
+);
 
 // Create a k8s namespace for operator
 const namespace = new k8s.core.v1.Namespace(


### PR DESCRIPTION
metrics-server is a runtime requirement for akka-platform-operator, so it does not
make sense to disable its installation.
