### PR TITLE
Multiple small improvements and code comments

### DIFF
--- a/aws/config.ts
+++ b/aws/config.ts
@@ -105,7 +105,7 @@ export class Mks {
 }
 
 export class AkkaOperator {
-  static readonly CharOpts: ChartOpts = {
+  static readonly ChartOpts: ChartOpts = {
     chart: "akka-operator",
     version: config.get<string>("akka.operator.version") || Versions.AkkaPlatformOperatorVersion,
     fetchOpts: {

--- a/aws/index.ts
+++ b/aws/index.ts
@@ -41,7 +41,7 @@ cloud.operatorServiceAccount(cluster, serviceAccountName, namespace);
 new k8s.helm.v3.Chart(
   "akka-operator",
   {
-    ...config.AkkaOperator.CharOpts,
+    ...config.AkkaOperator.ChartOpts,
     namespace: namespace.metadata.name,
     // chart values don't support shorthand value assignment syntax i.e. `serviceAccount.name: "foo"`
     values: {

--- a/aws/telemetry.ts
+++ b/aws/telemetry.ts
@@ -153,6 +153,8 @@ class Grafana {
           };
         });
 
+        // There is some repetition between this declaration and the one below (in `simpleInstall` function). If you are
+        // making changes that may affect it, remember to keep them in sync.
         new k8s.helm.v3.Chart(
           "grafana",
           {
@@ -210,6 +212,8 @@ class Grafana {
   }
 
   private simpleInstall(k8sProvider: k8s.Provider): void {
+    // There is some repetition between this declaration and the one above (in `install` function). If you are
+    // making changes that may affect it, remember to keep them in sync.
     new k8s.helm.v3.Chart(
       "grafana",
       {

--- a/gcp/gke.ts
+++ b/gcp/gke.ts
@@ -43,6 +43,15 @@ export class GcpCloud {
       location: gcp.config.zone,
       minMasterVersion: engineVersion,
       nodeVersion: engineVersion,
+      releaseChannel: {
+        // See available channels here:
+        // https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels
+        // Regular:
+        //    Access GKE and Kubernetes features reasonably soon after they debut, but on a version that
+        //    has been qualified over a longer period of time. Offers a balance of feature availability
+        //    and release stability, and is what we recommend for most users.
+        channel: "REGULAR"
+      },
       resourceLabels: {
         "pulumi-stack": pulumi.getStack(),
         "pulumi-project": pulumi.getProject(),
@@ -70,6 +79,7 @@ export class GcpCloud {
         version: engineVersion,
         management: {
           autoRepair: true,
+          autoUpgrade: true, // MUST be true if the releaseChannel is "REGULAR"
         },
       },
       {

--- a/gcp/gke.ts
+++ b/gcp/gke.ts
@@ -36,12 +36,19 @@ export class GcpCloud {
    * Creates a GCP cluster.
    */
   createKubernetesCluster(): GcpKubernetesCluster {
+    const createdAt = new Date();
     // Create a GKE cluster
     const engineVersion = gcp.container.getEngineVersions().then((v) => v.latestMasterVersion);
     const cluster = new gcp.container.Cluster(util.name("gke"), {
       location: gcp.config.zone,
       minMasterVersion: engineVersion,
       nodeVersion: engineVersion,
+      resourceLabels: {
+        "pulumi-stack": pulumi.getStack(),
+        "pulumi-project": pulumi.getProject(),
+        // Not using `getTime` to avoid updating the resource too often
+        "pulumi-created-at": `${createdAt.getUTCFullYear()}-${createdAt.getUTCMonth()}-${createdAt.getUTCDate()}`,
+      },
       networkingMode: "VPC_NATIVE",
       // needed for VPC native cluster
       // keeping the cidr blocks empty means GKE will automatically set them up

--- a/gcp/gke.ts
+++ b/gcp/gke.ts
@@ -40,14 +40,17 @@ export class GcpCloud {
     const engineVersion = gcp.container.getEngineVersions().then((v) => v.latestMasterVersion);
     const cluster = new gcp.container.Cluster(util.name("gke"), {
       location: gcp.config.zone,
-      initialNodeCount: 1,
       minMasterVersion: engineVersion,
       nodeVersion: engineVersion,
-      removeDefaultNodePool: true,
       networkingMode: "VPC_NATIVE",
       // needed for VPC native cluster
       // keeping the cidr blocks empty means GKE will automatically set them up
       ipAllocationPolicy: { clusterIpv4CidrBlock: "", servicesIpv4CidrBlock: "" },
+      // We can't create a cluster with no node pool defined, but we want to only use
+      // separately managed node pools. So we create the smallest possible default
+      // node pool and immediately delete it.
+      initialNodeCount: 1,
+      removeDefaultNodePool: true,
     });
 
     // separate node pool

--- a/gcp/gke.ts
+++ b/gcp/gke.ts
@@ -50,7 +50,7 @@ export class GcpCloud {
         //    Access GKE and Kubernetes features reasonably soon after they debut, but on a version that
         //    has been qualified over a longer period of time. Offers a balance of feature availability
         //    and release stability, and is what we recommend for most users.
-        channel: "REGULAR"
+        channel: "REGULAR",
       },
       resourceLabels: {
         "pulumi-stack": pulumi.getStack(),

--- a/gcp/gke.ts
+++ b/gcp/gke.ts
@@ -62,7 +62,9 @@ export class GcpCloud {
 
     // separate node pool
     const nodePool = new gcp.container.NodePool(
-      util.name("primary-np"),
+      // There is a short limit for the node pool name on GCP, and `util.name` appends
+      // multiple information to it, so better to keep the "base name" short.
+      util.name("primary"),
       {
         ...config.Gke.nodePoolArgs(cluster.name, gcp.config.zone),
         version: engineVersion,

--- a/gcp/telemetry.ts
+++ b/gcp/telemetry.ts
@@ -141,6 +141,8 @@ class Grafana {
         });
 
         const grafanaChart = new k8s.helm.v3.Chart(
+        // There is some repetition between this declaration and the one below (in `simpleInstall` function). If you are
+        // making changes that may affect it, remember to keep them in sync.
           "grafana",
           {
             chart: "grafana",
@@ -224,6 +226,8 @@ class Grafana {
   }
 
   private simpleInstall(k8sProvider: k8s.Provider, cluster: gcp.container.Cluster): void {
+    // There is some repetition between this declaration and the one above (in `install` function). If you are
+    // making changes that may affect it, remember to keep them in sync.
     new k8s.helm.v3.Chart(
       "grafana",
       {


### PR DESCRIPTION
This is a follow up to reviews in #17.

- aws: fix configuration const name
- aws: Add comments regarding code duplication
- gcp: Add comments regarding code duplication
- gcp: Add comment about why not using the default node pool
- gcp: Add labels to identify the cluster better in GCP UI
- gcp: Add comment about nodepool name limitation
- gcp: Use the regular channel
- gcp: Multiple minor improvements to Grafana installation
